### PR TITLE
32 allow prefixing variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 A lightweight self-healing config handler.
 
-## Quickstart
+## What is ConfigLite?
 
-Subclass from the base `BaseConfig` object and add your variables and defaults.
+`ConfigLite` aims to provide a simple "subclass and go" methodology for handling yaml-based file configs.
+
+Subclass from the base `BaseConfig` object and add your defaults.
+Then, create an instance of your new class, providing a list of paths to search through.
+If a config is found at once of these paths, it is used, otherwise a default config is created.
 
 You can then set import this from wherever is needed and access properties.
 
+For more details, see Usage below.
 
 ## Installation
 
@@ -21,12 +26,17 @@ Simply run `pip install configlite` to install it in your current environment.
 
 If you want to make changes to how configs are handled, you can clone this repo and run `pip install -e .` to install it in editable mode.
 
+> [!note]
+> Find a bug? Feel free to make an issue or pull request!
+
 ## Usage
 
 ### Creating a Config
 
 There are two methods of creating a config object.
+
 #### Direct Initialisation
+
 The simplest method to create a config, simply init the `BaseConfig` class and provide your defaults as an argument:
 
 ```python
@@ -40,13 +50,17 @@ CONFIG = BaseConfig(
         ...
     }
 )
-
 ```
 
+> [!tip]
+> Here, you may pass a single `path`, or a list of `paths`. The config will search through each path until it finds a match (See the section on Paths below for more info).
+
 #### As a Class
+
 If you wish to add extra methods, create a subclass of the base `BaseConfig` object, adding your parameters and their defaults to a `defaults` field.
 
 For example:
+
 ```python
 from configlite import BaseConfig
 
@@ -60,11 +74,13 @@ class MyConfig(BaseConfig):
 ```
 
 You must still initialise the config, however:
+
 ```python
 CONFIG = MyConfig(path="config.yaml")
 ```
 
 ### Access
+
 To use your created config, there are two methods:
 
 - "globally", where a single instance created.
@@ -73,6 +89,7 @@ To use your created config, there are two methods:
 #### Global
 
 To create a global config, set up the config as a parameter in the toplevel `__init__.py`:
+
 ```python
 CONFIG = MyConfig("./path/to/config.yaml")
 ```
@@ -88,6 +105,7 @@ value = CONFIG.value
 This is most useful if your code requires a single config file for everything.
 
 #### Local
+
 Or a local config, where you create an instance of your subclass wherever it is needed:
 
 ```python
@@ -100,10 +118,8 @@ value = config.value
 
 This can be useful if you are juggling multiple different config files dynamically.
 
-> \[!NOTE]
->
+> [!tip]
 > This method is only recommended for subclasses, as each instance requires the same arguments.
-
 
 ## Paths
 
@@ -129,11 +145,41 @@ CONFIG = Config(
 
 In this case, `Config` will take these steps:
 
-1) Search for `config.yaml` in the current working directory.
-2) If not found, search for `~/.config/app/config.yaml`.
-3) If still no file exists, create a default config at `~/.config/app/config.yaml`
+1. Search for `config.yaml` in the current working directory.
+2. If not found, search for `~/.config/app/config.yaml`.
+3. If still no file exists, create a default config at `~/.config/app/config.yaml`
 
 If we get to step 3, but then create a new config at `./config.yaml`, this will take priority over the one found at `~/.config/app/config.yaml`.
+
+## Environment Overrides
+
+You may also set a `prefix` property, which enables environment overrides.
+
+If we take our config from earlier, but add this feature:
+
+```python
+class MyConfig(BaseConfig):
+    defaults = {
+        "value": 10,
+        "name": "test",
+        "pi": 3.14,
+    }
+    prefix = "test_prefix"
+```
+
+Now, on initialisation, the config will search for environment variables starting with `test_prefix`
+
+If we `export test_prefix_value="foo"`, we will see the changes:
+
+```python
+cfg = MyConfig(...)
+
+cfg.value
+> "foo"
+```
+
+> [!important]
+> This is case-sensitive.
 
 ## Example
 

--- a/configlite/__init__.py
+++ b/configlite/__init__.py
@@ -2,4 +2,4 @@ from configlite.config import BaseConfig
 
 
 __all__ = ["BaseConfig"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -13,7 +13,7 @@ class BaseConfig(FileMixin):
 
     def __init__(
         self,
-        path: Path | str | list[Path] | list[Path] | None = None,
+        path: Path | str | list[Path] | list[str] | None = None,
         paths: list[Path | str] | None = None,
         defaults: dict[str, Any] | None = None,
     ) -> None:

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -42,6 +42,7 @@ class BaseConfig(FileMixin):
         if not self.abspath.exists() and autocreate:
             self._ensure_file_integrity(overwrite=True)
 
+        self._env_overrides = {}
         if self.prefix is not None:
             for var in os.environ:
                 if not var.startswith(self.prefix):
@@ -51,7 +52,7 @@ class BaseConfig(FileMixin):
                     stripped = stripped[1:]
 
                 if stripped in self.data:
-                    self.data[stripped] = os.environ.get(var)
+                    self._env_overrides[stripped] = os.environ.get(var)
 
     def __getattribute__(self, name: str) -> Any:
         """Proxy attribute access. If the item is deferred, return the get instead."""
@@ -74,6 +75,9 @@ class BaseConfig(FileMixin):
         If the key exists within the attributes, it is read from file.
         Otherwise, the default value is returned. If no default is provided, a KeyError is raised.
         """
+        # check env overrides first
+        if key in self._env_overrides:
+            return self._env_overrides.get(key)
         # prefer file read
         if self.abspath.exists():
             self._ensure_file_integrity()

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -16,7 +16,7 @@ class BaseConfig(FileMixin):
         path: Path | str | list[Path] | list[str] | None = None,
         paths: list[Path | str] | None = None,
         defaults: dict[str, Any] | None = None,
-        autocreate: bool = False,
+        autocreate: bool = True,
     ) -> None:
         """Initialize the config object.
 

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -16,17 +16,19 @@ class BaseConfig(FileMixin):
         path: Path | str | list[Path] | list[str] | None = None,
         paths: list[Path | str] | None = None,
         defaults: dict[str, Any] | None = None,
+        autocreate: bool = False,
     ) -> None:
         """Initialize the config object.
 
         Args:
-            path (str, Path): The path to the config file. If the file does not exist, it will be created.
-            paths (list[str | Path]):
+            path (str, Path): The path to the config file.
+            paths (list[Path | str]):
                 A list of paths to search for the config file.
                 If it is not found in any, the last one in the list is used for creation.
             defaults (dict): Default values for the config. Overrides any set at the class level.
+            autocreate (bool): Ensure that the file exists at init
         """
-        super().__init__(path=path, paths=paths)
+        super().__init__(path=path, paths=paths, autocreate=autocreate)
 
         # init with the hardcoded defaults
         self.data = self.defaults.copy()
@@ -36,6 +38,9 @@ class BaseConfig(FileMixin):
 
         elif self.path.exists():
             self._ensure_file_integrity()
+
+        if not self.abspath.exists() and autocreate:
+            self._ensure_file_integrity(overwrite=True)
 
         if self.prefix is not None:
             for var in os.environ:

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,7 @@ class BaseConfig(FileMixin):
     """Lightweight Self-Healing config object."""
 
     defaults: dict[str, Any] = {}
+    prefix: str | None = None
 
     def __init__(
         self,
@@ -34,6 +36,17 @@ class BaseConfig(FileMixin):
 
         elif self.path.exists():
             self._ensure_file_integrity()
+
+        if self.prefix is not None:
+            for var in os.environ:
+                if not var.startswith(self.prefix):
+                    continue
+                stripped = var.removeprefix(self.prefix)
+                if stripped.startswith("_"):
+                    stripped = stripped[1:]
+
+                if stripped in self.data:
+                    self.data[stripped] = os.environ.get(var)
 
     def __getattribute__(self, name: str) -> Any:
         """Proxy attribute access. If the item is deferred, return the get instead."""

--- a/configlite/filemixin.py
+++ b/configlite/filemixin.py
@@ -1,6 +1,6 @@
 import os
-from pathlib import Path
 import shutil
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -13,17 +13,19 @@ class FileMixin:
 
     def __init__(
         self,
-        path: Path | str | list[Path] | list[Path] | None = None,
+        path: Path | str | list[Path] | list[str] | None = None,
         paths: list[Path | str] | None = None,
+        autocreate: bool = False,
     ) -> None:
         """Provides methods for handling the file portion of the config.
 
         Args:
-            path:
-                The path to the config file. If the file does not exist, it will be created.
-            paths:
+            path (Path, str):
+                The path to the config file.
+            paths (list[Path | str]):
                 A list of paths to search for the config file.
                 If it is not found in any, the last one in the list is used for creation.
+            autocreate (bool): Ensure that the file exists at init
         """
         if not path and not paths:
             raise ValueError("Either `path` or `paths` must be provided.")

--- a/configlite/filemixin.py
+++ b/configlite/filemixin.py
@@ -15,7 +15,7 @@ class FileMixin:
         self,
         path: Path | str | list[Path] | list[str] | None = None,
         paths: list[Path | str] | None = None,
-        autocreate: bool = False,
+        autocreate: bool = True,
     ) -> None:
         """Provides methods for handling the file portion of the config.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 version = {attr = 'configlite.__version__'}
 
 [tool.bumpver]
-current_version = "0.2.3"
+current_version = "0.2.4"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "[clean] bump version {old_version} -> {new_version}"
 commit = true

--- a/tests/test_autocreate.py
+++ b/tests/test_autocreate.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import yaml
+
+from configlite import BaseConfig
+from tests.conftest import verify_variable
+
+
+class ConfigTest(BaseConfig):
+    defaults = {
+        "foo": "foo",
+    }
+
+
+def test_autocreate_false_creates_no_file() -> None:
+    """Test that autocreate=False does not instantly create the file."""
+    cfg = ConfigTest(path="test_config.yaml", autocreate=False)
+    assert not cfg.abspath.exists()
+
+
+def test_autocreate_true_creates_file() -> None:
+    """Test that setting autocreate=True will automatically create the last file in the list."""
+    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
+    assert cfg.abspath.exists()
+    verify_variable(cfg.path, "foo", "foo")
+
+
+def test_autocreate_true_creates_last_file() -> None:
+    """Test that setting autocreate=True will automatically create the last file in the list."""
+    cfg = ConfigTest(path=["priority.yaml", "test_config.yaml"], autocreate=True)
+    assert cfg.abspath.exists()
+    assert cfg.path.name == "test_config.yaml"
+    verify_variable(cfg.path, "foo", "foo")
+
+
+def test_autocreate_does_not_overwrite_files() -> None:
+    """Test that using autocreate does not overwrite already existing files."""
+    last_file = Path("test_config.yaml")
+    with last_file.open("w+") as o:
+        yaml.dump({"foo": "bar"}, o)
+    cfg = ConfigTest(path=["priority.yaml", "test_config.yaml"], autocreate=True)
+
+    assert cfg.abspath.exists()
+    assert cfg.path == last_file
+    assert cfg.foo == "bar"
+
+    verify_variable(last_file, "foo", "bar")
+
+
+def test_autocreate_does_not_overwrite_priority_files() -> None:
+    """Test that using autocreate does not overwrite files that are higher in the path list."""
+    priority_file = Path("priority.yaml")
+    with priority_file.open("w+") as o:
+        yaml.dump({"foo": "bar"}, o)
+    cfg = ConfigTest(path=["priority.yaml", "test_config.yaml"], autocreate=True)
+
+    assert cfg.abspath.exists()
+    assert cfg.path == priority_file
+    assert cfg.foo == "bar"
+
+    verify_variable(priority_file, "foo", "bar")

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -7,10 +7,10 @@ class MyConfig(BaseConfig):
     defaults = {"foo": "bar"}
 
 
-def test_no_file_on_init() -> None:
-    """Check that simply initialising a config does not create a file instantly."""
+def test_file_on_init() -> None:
+    """Check that initialising a config does create a file instantly."""
     file = Path("test.yaml")
     my_config = MyConfig(path=file)
 
-    assert not file.exists()
+    assert file.exists()
     assert my_config.path == file

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -1,0 +1,39 @@
+import pytest
+
+from configlite import BaseConfig
+
+
+class ConfigTest(BaseConfig):
+    defaults = {
+        "INIT_VAR": "foo",
+    }
+    prefix = "MYPREFIX"
+
+
+def test_override_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that we return the value of a set environment variable."""
+    monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
+    cfg = ConfigTest(path="test_config.yaml")
+    assert cfg.get("INIT_VAR") == "hello"
+
+
+def test_missing_no_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that we're not just picking up any old variables."""
+    monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
+    cfg = ConfigTest(path="test_config.yaml")
+    with pytest.raises(KeyError, match=".*not found in Config!"):
+        cfg.get("NONE_VAR") is None
+
+
+def test_missing_with_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check that we can still default."""
+    monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
+    cfg = ConfigTest(path="test_config.yaml")
+    assert cfg.get("NONE_VAR", "fallback") == "fallback"
+
+
+def test_missing_with_default_on_class(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Returns the default value when the variable is not set."""
+    monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
+    cfg = ConfigTest(path="test_config.yaml")
+    assert cfg.get("INIT_VAR") == "foo"

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -13,14 +13,14 @@ class ConfigTest(BaseConfig):
 def test_override_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that we return the value of a set environment variable."""
     monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
-    cfg = ConfigTest(path="test_config.yaml")
+    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
     assert cfg.get("INIT_VAR") == "hello"
 
 
 def test_missing_no_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Check that we're not just picking up any old variables."""
     monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml")
+    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
     with pytest.raises(KeyError, match=".*not found in Config!"):
         cfg.get("NONE_VAR") is None
 
@@ -28,12 +28,12 @@ def test_missing_no_default(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_missing_with_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Check that we can still default."""
     monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml")
+    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
     assert cfg.get("NONE_VAR", "fallback") == "fallback"
 
 
 def test_missing_with_default_on_class(monkeypatch: pytest.MonkeyPatch) -> None:
     """Returns the default value when the variable is not set."""
     monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml")
+    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
     assert cfg.get("INIT_VAR") == "foo"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 
 import yaml
+
 from configlite.config import BaseConfig
+from tests.conftest import verify_variable
 
 
 class ConfigTest(BaseConfig):
@@ -11,43 +13,61 @@ class ConfigTest(BaseConfig):
     }
 
 
-def test_default_to_last():
+def test_default_to_last(tmpdir):
     """Tests that the default path is the last one in the list."""
 
-    workdir = Path(os.getcwd()) / "config_local.yaml"
-    lastdir = workdir / ".config" / "config.yaml"
+    firstpath = tmpdir / "config_local.yaml"
+    lastpath = tmpdir / ".config" / "config.yaml"
 
-    config = ConfigTest(paths=[workdir, lastdir])
+    config = ConfigTest(paths=[firstpath, lastpath])
 
-    assert config.path == lastdir
+    assert config.path == lastpath
 
     # now test that creating a config in the higher priority directories works
-    with open(workdir, "w+") as o:
+    with open(firstpath, "w+") as o:
         yaml.dump({"foo": "bar"}, o)
 
-    assert config.path == workdir
+    assert config.path == firstpath
     assert config.foo == "bar"
 
 
-def test_inner_dir_access():
+def test_inner_dir_access(tmpdir):
     """Tests that configs in inner directories can be accessed."""
-    cfg = ConfigTest(path="inner/config.yaml")
+    inner_dir = tmpdir / "inner"
+    cfg = ConfigTest(path=inner_dir / "config.yaml")
 
-    assert not Path("inner").exists()
+    assert inner_dir.exists()
 
     assert cfg.foo == "foo"
+    verify_variable(cfg.path, "foo", "foo")
 
 
-def test_stacked_files() -> None:
+def test_stacked_files(tmpdir) -> None:
     """Test that specifying both path and paths does not cause problems."""
-    cfg = ConfigTest(path="config.yaml", paths=["backup.yaml", "another.yaml"])
+    cfg = ConfigTest(
+        path=tmpdir / "config.yaml",
+        paths=[tmpdir / "backup.yaml", tmpdir / "another.yaml"],
+        autocreate=False,
+    )
 
     assert len(cfg._paths) == 3
-    assert cfg.paths[0] == Path("config.yaml")
+    assert cfg.paths[0] == tmpdir / "config.yaml"
 
     # check path list
-    assert cfg.paths == [Path(p) for p in ["config.yaml", "backup.yaml", "another.yaml"]]
-    # make sure that the paths list is exactly as specified
-    assert cfg.paths != [Path(p).resolve() for p in ["config.yaml", "backup.yaml", "another.yaml"]]
+    assert cfg.paths == [
+        Path(p)
+        for p in [
+            tmpdir / "config.yaml",
+            tmpdir / "backup.yaml",
+            tmpdir / "another.yaml",
+        ]
+    ]
     # also add a check to ensure we _can_ get abspaths
-    assert cfg.abspaths == [Path(p).resolve() for p in ["config.yaml", "backup.yaml", "another.yaml"]]
+    assert cfg.abspaths == [
+        Path(p).resolve()
+        for p in [
+            tmpdir / "config.yaml",
+            tmpdir / "backup.yaml",
+            tmpdir / "another.yaml",
+        ]
+    ]


### PR DESCRIPTION
Adds the ability to override variables via the environment. Set the `prefix` property on a `BaseConfig` subclass to activate.

Closes #32 