### PR TITLE
34 environment variables are cached at init

### DIFF
--- a/configlite/__init__.py
+++ b/configlite/__init__.py
@@ -2,4 +2,4 @@ from configlite.config import BaseConfig
 
 
 __all__ = ["BaseConfig"]
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -42,18 +42,6 @@ class BaseConfig(FileMixin):
         if not self.abspath.exists() and autocreate:
             self._ensure_file_integrity(overwrite=True)
 
-        self._env_overrides = {}
-        if self.prefix is not None:
-            for var in os.environ:
-                if not var.startswith(self.prefix):
-                    continue
-                stripped = var.removeprefix(self.prefix)
-                if stripped.startswith("_"):
-                    stripped = stripped[1:]
-
-                if stripped in self.data:
-                    self._env_overrides[stripped] = os.environ.get(var)
-
     def __getattribute__(self, name: str) -> Any:
         """Proxy attribute access. If the item is deferred, return the get instead."""
         if (
@@ -69,6 +57,17 @@ class BaseConfig(FileMixin):
         """Proxy subscript access to read method."""
         return self.get(key)
 
+    def _get_env(self, key: str) -> str | None:
+        """Check the environment for a prefixed override.
+
+        Uses the prefix to search. For example, if we have prefix=PREFIX, and search for key="FOO",
+        Perform a check for PREFIX_FOO
+        """
+        if self.prefix is None:
+            return None
+        normalised = self.prefix if self.prefix.endswith("_") else f"{self.prefix}_"
+        return os.environ.get(f"{normalised}{key}", None)
+
     def get(self, key: str, default: Any | None = None) -> Any:
         """Expose the python `get` property.
 
@@ -76,8 +75,10 @@ class BaseConfig(FileMixin):
         Otherwise, the default value is returned. If no default is provided, a KeyError is raised.
         """
         # check env overrides first
-        if key in self._env_overrides:
-            return self._env_overrides.get(key)
+        from_env = self._get_env(key)
+        if from_env is not None:
+            return from_env
+
         # prefer file read
         if self.abspath.exists():
             self._ensure_file_integrity()

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -86,7 +86,7 @@ class BaseConfig(FileMixin):
             file_data = self._read()
             if key in file_data:
                 return file_data[key]
-            if default:
+            if default is not None:
                 return default
         # fallback to internal data
         if key in self.data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 version = {attr = 'configlite.__version__'}
 
 [tool.bumpver]
-current_version = "0.2.4"
+current_version = "0.2.5"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "[clean] bump version {old_version} -> {new_version}"
 commit = true

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -24,6 +24,8 @@ class TestEnvOverride:
         monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
         cfg = cfg(path="test_config.yaml", autocreate=True)
         assert cfg.get("INIT_VAR") == "hello"
+        assert cfg.INIT_VAR == "hello"
+        assert cfg["INIT_VAR"] == "hello"
 
     def test_missing_no_default(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
         """Check that we're not just picking up any old variables."""
@@ -45,9 +47,13 @@ class TestEnvOverride:
         monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
         cfg = cfg(path="test_config.yaml", autocreate=True)
         assert cfg.get("INIT_VAR") == "foo"
+        assert cfg.INIT_VAR == "hello"
+        assert cfg["INIT_VAR"] == "hello"
 
     def test_get_reads_current_env(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that `get` reflects the true state of the environment."""
         cfg = cfg(path="test_config.yaml", autocreate=True)
         monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
         assert cfg.get("INIT_VAR") == "hello"
+        assert cfg.INIT_VAR == "hello"
+        assert cfg["INIT_VAR"] == "hello"

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -10,30 +10,44 @@ class ConfigTest(BaseConfig):
     prefix = "MYPREFIX"
 
 
-def test_override_with_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that we return the value of a set environment variable."""
-    monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
-    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
-    assert cfg.get("INIT_VAR") == "hello"
+class ConfigTestUnderscore(BaseConfig):
+    defaults = {
+        "INIT_VAR": "foo",
+    }
+    prefix = "MYPREFIX_"
 
 
-def test_missing_no_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Check that we're not just picking up any old variables."""
-    monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
-    with pytest.raises(KeyError, match=".*not found in Config!"):
-        cfg.get("NONE_VAR") is None
+@pytest.mark.parametrize("cfg", [ConfigTest, ConfigTestUnderscore])
+class TestEnvOverride:
+    def test_override_with_env(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that we return the value of a set environment variable."""
+        monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
+        cfg = cfg(path="test_config.yaml", autocreate=True)
+        assert cfg.get("INIT_VAR") == "hello"
 
+    def test_missing_no_default(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Check that we're not just picking up any old variables."""
+        monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
+        cfg = cfg(path="test_config.yaml", autocreate=True)
+        with pytest.raises(KeyError, match=".*not found in Config!"):
+            cfg.get("NONE_VAR") is None
 
-def test_missing_with_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Check that we can still default."""
-    monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
-    assert cfg.get("NONE_VAR", "fallback") == "fallback"
+    def test_missing_with_default(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Check that we can still default."""
+        monkeypatch.delenv("MYPREFIX_NONE_VAR", raising=False)
+        cfg = cfg(path="test_config.yaml", autocreate=True)
+        assert cfg.get("NONE_VAR", "fallback") == "fallback"
 
+    def test_missing_with_default_on_class(
+        self, cfg, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns the default value when the variable is not set."""
+        monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
+        cfg = cfg(path="test_config.yaml", autocreate=True)
+        assert cfg.get("INIT_VAR") == "foo"
 
-def test_missing_with_default_on_class(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Returns the default value when the variable is not set."""
-    monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
-    cfg = ConfigTest(path="test_config.yaml", autocreate=True)
-    assert cfg.get("INIT_VAR") == "foo"
+    def test_get_reads_current_env(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that `get` reflects the true state of the environment."""
+        cfg = cfg(path="test_config.yaml", autocreate=True)
+        monkeypatch.setenv("MYPREFIX_INIT_VAR", "hello")
+        assert cfg.get("INIT_VAR") == "hello"

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -47,8 +47,8 @@ class TestEnvOverride:
         monkeypatch.delenv("MYPREFIX_INIT_VAR", raising=False)
         cfg = cfg(path="test_config.yaml", autocreate=True)
         assert cfg.get("INIT_VAR") == "foo"
-        assert cfg.INIT_VAR == "hello"
-        assert cfg["INIT_VAR"] == "hello"
+        assert cfg.INIT_VAR == "foo"
+        assert cfg["INIT_VAR"] == "foo"
 
     def test_get_reads_current_env(self, cfg, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test that `get` reflects the true state of the environment."""


### PR DESCRIPTION
Changes how the environment search works to always check on `get`, rather than caching the environment at config init.

Also fixes a bug which would cause `get(..., default=False)` to behave unexpectedly