### PR TITLE
Update ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.11
+    rev: v0.16.0
     hooks:
       # Run the linter.
       - id: ruff-check
@@ -18,6 +18,6 @@ repos:
         types_or: [ python, pyi ]
         args: [--exclude=tests]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
+    rev: v8.30.0
     hooks:
       - id: gitleaks

--- a/configlite/__init__.py
+++ b/configlite/__init__.py
@@ -1,5 +1,4 @@
 from configlite.config import BaseConfig
 
-
 __all__ = ["BaseConfig"]
 __version__ = "0.2.5"

--- a/configlite/config.py
+++ b/configlite/config.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from configlite.filemixin import FileMixin
 
@@ -8,7 +8,7 @@ from configlite.filemixin import FileMixin
 class BaseConfig(FileMixin):
     """Lightweight Self-Healing config object."""
 
-    defaults: dict[str, Any] = {}
+    defaults: ClassVar[dict[str, Any]] = {}
     prefix: str | None = None
 
     def __init__(

--- a/configlite/filemixin.py
+++ b/configlite/filemixin.py
@@ -59,6 +59,11 @@ class FileMixin:
         return self._find_path()
 
     @property
+    def backup_path(self) -> Path:
+        """Path to the backup file used during healing."""
+        return Path(self.path.name + ".bk")
+
+    @property
     def abspath(self) -> Path:
         """Absolute path to the config file."""
         return self.path.resolve()
@@ -133,13 +138,12 @@ class FileMixin:
             return data
         # In the case of a broken file, back it up and create a default one
         target_path = self.path
-        backup_name = f"{self.filename}.bk"
         print(
-            f"WARNING: Config file {target_path} failed to load.\n\tBacking up the file to: {backup_name}...",
+            f"WARNING: Config file {target_path} failed to load.\n\tBacking up the file to: {self.backup_path}...",
             end=" ",
         )
         try:
-            shutil.move(target_path, backup_name)
+            shutil.move(target_path, self.backup_path)
         except:
             print("Error.")
             raise

--- a/configlite/filemixin.py
+++ b/configlite/filemixin.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -9,7 +9,7 @@ import yaml
 class FileMixin:
     """Mixin class for handling file operations."""
 
-    data = {}
+    data: ClassVar[dict] = {}
 
     def __init__(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pre-commit>=4.5.0",
     "pytest>=9.0.1",
     "pytest-cov>=7.0.0",
+    "ruff>=0.16.0",
 ]
 
 [tool.setuptools.dynamic]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from typing import Any
+
 import pytest
 import yaml
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -1,9 +1,12 @@
+from typing import ClassVar
+
 import pytest
+
 from configlite.config import BaseConfig
 
 
 class ConfigTest(BaseConfig):
-    defaults = {"foo": "foo"}
+    defaults: ClassVar[dict] = {"foo": "foo"}
 
 
 def test_attribute_access():

--- a/tests/test_autocreate.py
+++ b/tests/test_autocreate.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 
@@ -7,7 +8,7 @@ from tests.conftest import verify_variable
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,15 @@
-from configlite.config import BaseConfig
+from typing import ClassVar
+
 import yaml
+
+from configlite.config import BaseConfig
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "test": "foo",
     }
+
 
 def test_ensure_empty() -> None:
     assert BaseConfig("test.yaml").attributes == []
@@ -13,7 +17,7 @@ def test_ensure_empty() -> None:
 
 def test_attributes() -> None:
     class TestConfig(BaseConfig):
-        defaults = {"test": 10}
+        defaults: ClassVar[dict] = {"test": 10}
 
     assert TestConfig("test.yaml").attributes == ["test"]
 

--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -1,10 +1,11 @@
 from pathlib import Path
+from typing import ClassVar
 
 from configlite.config import BaseConfig
 
 
 class MyConfig(BaseConfig):
-    defaults = {"foo": "bar"}
+    defaults: ClassVar[dict] = {"foo": "bar"}
 
 
 def test_file_on_init() -> None:

--- a/tests/test_defaults_override.py
+++ b/tests/test_defaults_override.py
@@ -1,16 +1,14 @@
+from typing import ClassVar
+
 from configlite.config import BaseConfig
 from tests.conftest import verify_variable
 
 
 class Config(BaseConfig):
-    defaults = {
-        "foo": "foo"
-    }
+    defaults: ClassVar[dict] = {"foo": "foo"}
 
 
-CONFIG = {
-    "foo": "bar"
-}
+CONFIG = {"foo": "bar"}
 
 
 def test_update_when_file() -> None:

--- a/tests/test_extra_methods.py
+++ b/tests/test_extra_methods.py
@@ -1,8 +1,10 @@
+from typing import ClassVar
+
 from configlite.config import BaseConfig
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "test_value": 42,
         "name": "Test_Name",
     }

--- a/tests/test_filemixin.py
+++ b/tests/test_filemixin.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+
 from configlite.filemixin import FileMixin
 
 

--- a/tests/test_from_prefix.py
+++ b/tests/test_from_prefix.py
@@ -1,17 +1,19 @@
+from typing import ClassVar
+
 import pytest
 
 from configlite import BaseConfig
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "INIT_VAR": "foo",
     }
     prefix = "MYPREFIX"
 
 
 class ConfigTestUnderscore(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "INIT_VAR": "foo",
     }
     prefix = "MYPREFIX_"

--- a/tests/test_healing.py
+++ b/tests/test_healing.py
@@ -1,5 +1,5 @@
-import os
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 
@@ -9,7 +9,7 @@ from .conftest import verify_variable
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
         "val": 10,
     }
@@ -93,13 +93,13 @@ def test_remove_variable():
     """Test that modifying the config updates the file correctly."""
 
     class ConfigTest_1(BaseConfig):
-        defaults = {
+        defaults: ClassVar[dict] = {
             "foo": "foo",
             "bar": "bar",
         }
 
     class ConfigTest_2(BaseConfig):
-        defaults = {
+        defaults: ClassVar[dict] = {
             "foo": "foo",
         }
 
@@ -117,12 +117,12 @@ def test_modify_variable():
     """Test that modifying the config updates the file correctly."""
 
     class ConfigTest_1(BaseConfig):
-        defaults = {
+        defaults: ClassVar[dict] = {
             "foo": "foo",
         }
 
     class ConfigTest_2(BaseConfig):
-        defaults = {
+        defaults: ClassVar[dict] = {
             "foo": "foo",
             "new": "new_value",
         }

--- a/tests/test_healing.py
+++ b/tests/test_healing.py
@@ -2,7 +2,9 @@ import os
 from pathlib import Path
 
 import yaml
+
 from configlite.config import BaseConfig
+
 from .conftest import verify_variable
 
 
@@ -24,7 +26,7 @@ def test_restore_file(capsys):
     assert config.foo == "foo"
     assert config.val == 10
 
-    assert os.path.exists(f"{file}.bk")
+    assert config.backup_path.exists()
     assert "WARNING" in capsys.readouterr().out
 
     assert verify_variable(file, "foo", "foo")
@@ -42,10 +44,11 @@ def test_restore_file_priority(capsys):
     assert config.foo == "foo"
     assert config.val == 10
 
-    assert os.path.exists(f"{file_a}.bk")
+    assert config.backup_path.exists()
     assert "WARNING" in capsys.readouterr().out
 
     assert verify_variable(file_a, "foo", "foo")
+
 
 def test_mangled_file(capsys):
     file = Path("test.yaml")
@@ -58,7 +61,7 @@ def test_mangled_file(capsys):
     assert config.foo == "foo"
     assert config.val == 10
 
-    assert os.path.exists(f"{file}.bk")
+    assert config.backup_path.exists()
     assert "WARNING" in capsys.readouterr().out
 
 
@@ -88,6 +91,7 @@ def test_delete_variable():
 
 def test_remove_variable():
     """Test that modifying the config updates the file correctly."""
+
     class ConfigTest_1(BaseConfig):
         defaults = {
             "foo": "foo",
@@ -111,6 +115,7 @@ def test_remove_variable():
 
 def test_modify_variable():
     """Test that modifying the config updates the file correctly."""
+
     class ConfigTest_1(BaseConfig):
         defaults = {
             "foo": "foo",
@@ -129,3 +134,11 @@ def test_modify_variable():
     cfg = ConfigTest_2("test.yaml")
     assert verify_variable(cfg.path, "foo", "foo")
     assert verify_variable(cfg.path, "new", "new_value")
+
+
+def test_no_immediate_backup() -> None:
+    """Tests that creating a config does not create a backup file immediately."""
+    file = Path("config.yaml")
+    cfg = ConfigTest(path=file)
+
+    assert not cfg.backup_path.exists()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,12 +1,15 @@
 from pathlib import Path
+from typing import ClassVar
+
 import pytest
 import yaml
+
 from configlite.config import BaseConfig
 from tests.conftest import verify_variable
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,5 +1,5 @@
-import os
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 
@@ -8,7 +8,7 @@ from tests.conftest import verify_variable
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,15 +1,18 @@
+from typing import ClassVar
+
 import pytest
+
 from configlite.config import BaseConfig
 
 
 class ConfigTest(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 
 
 class ConfigWithMethods(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 
@@ -18,7 +21,7 @@ class ConfigWithMethods(BaseConfig):
 
 
 class ConfigWithProperty(BaseConfig):
-    defaults = {
+    defaults: ClassVar[dict] = {
         "foo": "foo",
     }
 
@@ -33,7 +36,7 @@ class ConfigWithProperty(BaseConfig):
         ConfigTest,
         ConfigWithMethods,
         ConfigWithProperty,
-    ]
+    ],
 )
 def test_attributes(config_class) -> None:
     """Tests that the attributes property returns the correct list of attributes."""

--- a/tests/test_silent.py
+++ b/tests/test_silent.py
@@ -1,8 +1,10 @@
+from typing import ClassVar
+
 from configlite.config import BaseConfig
 
 
 class Config(BaseConfig):
-    defaults = {"foo": "foo"}
+    defaults: ClassVar[dict] = {"foo": "foo"}
 
 
 def test_silent(capsys) -> None:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,13 +1,16 @@
+from typing import ClassVar
+
 from configlite.config import BaseConfig
 
 
 class ConfigA(BaseConfig):
-    defaults = {"param1": "value1"}
+    defaults: ClassVar[dict] = {"param1": "value1"}
 
 
 class ConfigB(BaseConfig):
     """Simulate updating the config to include a new parameter."""
-    defaults = {
+
+    defaults: ClassVar[dict] = {
         "param1": "value1",
         "param2": "value2",
     }

--- a/usage.py
+++ b/usage.py
@@ -1,6 +1,8 @@
 from pathlib import Path
-from configlite import BaseConfig
+
 import yaml
+
+from configlite import BaseConfig
 
 
 class MyConfig(BaseConfig):

--- a/uv.lock
+++ b/uv.lock
@@ -51,21 +51,28 @@ wheels = [
 name = "configlite"
 source = { virtual = "." }
 dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+dev = [
     { name = "bumpver" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pyyaml" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "bumpver", specifier = ">=2025.1131" },
-    { name = "pre-commit", specifier = ">=4.5.0" },
-    { name = "pytest", specifier = ">=9.0.1" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "bumpver", marker = "extra == 'dev'", specifier = ">=2025.1131" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.1" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.0" },
 ]
+provides-extras = ["dev"]
 
 [[package]]
 name = "coverage"
@@ -383,6 +390,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates pre-commit checks, which involves updating to `ruff==0.16.0` and applies the `ClassVar` fix to `BaseConfig`

Closes #36 